### PR TITLE
chore: update agentkeepalive to 4.6.0 to avoid depd

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: 4.0.1
         version: https://registry.npmjs.org/@types/string.prototype.matchall/-/string.prototype.matchall-4.0.1.tgz
       agentkeepalive:
-        specifier: 4.2.1
-        version: https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz
+        specifier: 4.6.0
+        version: 4.6.0
       ci-info:
         specifier: ^3.9.0
         version: 3.9.0
@@ -3625,9 +3625,8 @@ packages:
     version: 6.0.2
     engines: {node: '>= 6.0.0'}
 
-  agentkeepalive@https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz:
-    resolution: {integrity: sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==, tarball: https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz}
-    version: 4.2.1
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
   aggregate-error@3.1.0:
@@ -4853,11 +4852,6 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
-
-  depd@https://registry.npmjs.org/depd/-/depd-1.1.2.tgz:
-    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==, tarball: https://registry.npmjs.org/depd/-/depd-1.1.2.tgz}
-    version: 1.1.2
-    engines: {node: '>= 0.6'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -6307,9 +6301,8 @@ packages:
     version: 2.1.0
     engines: {node: '>=10.17.0'}
 
-  humanize-ms@https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==, tarball: https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz}
-    version: 1.2.1
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   humanize-string@2.1.0:
     resolution: {integrity: sha512-sQ+hqmxyXW8Cj7iqxcQxD7oSy3+AXnIZXdUF9lQMkzaG8dtbKAB8U7lCtViMnwQ+MpdCKsO2Kiij3G6UUXq/Xg==}
@@ -7630,10 +7623,6 @@ packages:
   ms@https://registry.npmjs.org/ms/-/ms-2.1.2.tgz:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==, tarball: https://registry.npmjs.org/ms/-/ms-2.1.2.tgz}
     version: 2.1.2
-
-  ms@https://registry.npmjs.org/ms/-/ms-2.1.3.tgz:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==, tarball: https://registry.npmjs.org/ms/-/ms-2.1.3.tgz}
-    version: 2.1.3
 
   multicast-dns@7.2.5:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
@@ -13935,7 +13924,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 6.19.0(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.2.2))(eslint@8.56.0)(typescript@5.2.2)
       '@typescript-eslint/parser': 6.19.0(eslint@8.56.0)(typescript@5.2.2)
       eslint: 8.56.0
-      eslint-config-standard-with-typescript: 39.1.1(@typescript-eslint/eslint-plugin@6.19.0(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.2.2))(eslint@8.56.0)(typescript@5.2.2))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.2.2))(eslint@8.56.0))(eslint-plugin-n@16.6.2(eslint@8.56.0))(eslint-plugin-promise@6.1.1(eslint@7.32.0))(eslint@8.56.0)(typescript@5.2.2)
+      eslint-config-standard-with-typescript: 39.1.1(@typescript-eslint/eslint-plugin@6.19.0(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.2.2))(eslint@8.56.0)(typescript@5.2.2))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.2.2))(eslint@8.56.0))(eslint-plugin-n@16.6.2(eslint@7.32.0))(eslint-plugin-promise@6.1.1(eslint@7.32.0))(eslint@8.56.0)(typescript@5.2.2)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.2.2))(eslint@8.56.0)
       eslint-plugin-n: 16.6.2(eslint@8.56.0)
       eslint-plugin-node: 11.1.0(eslint@8.56.0)
@@ -18737,13 +18726,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  agentkeepalive@https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz:
+  agentkeepalive@4.6.0:
     dependencies:
-      debug: https://registry.npmjs.org/debug/-/debug-4.3.4.tgz
-      depd: https://registry.npmjs.org/depd/-/depd-1.1.2.tgz
-      humanize-ms: https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz
-    transitivePeerDependencies:
-      - supports-color
+      humanize-ms: 1.2.1
 
   aggregate-error@3.1.0:
     dependencies:
@@ -20266,8 +20251,6 @@ snapshots:
 
   depd@2.0.0: {}
 
-  depd@https://registry.npmjs.org/depd/-/depd-1.1.2.tgz: {}
-
   dequal@2.0.3: {}
 
   des.js@1.1.0:
@@ -20829,12 +20812,12 @@ snapshots:
     dependencies:
       eslint: 7.32.0
 
-  eslint-config-standard-with-typescript@39.1.1(@typescript-eslint/eslint-plugin@6.19.0(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.2.2))(eslint@8.56.0)(typescript@5.2.2))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.2.2))(eslint@8.56.0))(eslint-plugin-n@16.6.2(eslint@8.56.0))(eslint-plugin-promise@6.1.1(eslint@7.32.0))(eslint@8.56.0)(typescript@5.2.2):
+  eslint-config-standard-with-typescript@39.1.1(@typescript-eslint/eslint-plugin@6.19.0(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.2.2))(eslint@8.56.0)(typescript@5.2.2))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.2.2))(eslint@8.56.0))(eslint-plugin-n@16.6.2(eslint@7.32.0))(eslint-plugin-promise@6.1.1(eslint@7.32.0))(eslint@8.56.0)(typescript@5.2.2):
     dependencies:
       '@typescript-eslint/eslint-plugin': 6.19.0(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.2.2))(eslint@8.56.0)(typescript@5.2.2)
       '@typescript-eslint/parser': 6.19.0(eslint@8.56.0)(typescript@5.2.2)
       eslint: 8.56.0
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.2.2))(eslint@8.56.0))(eslint-plugin-n@16.6.2(eslint@8.56.0))(eslint-plugin-promise@6.1.1(eslint@7.32.0))(eslint@8.56.0)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.2.2))(eslint@8.56.0))(eslint-plugin-n@16.6.2(eslint@7.32.0))(eslint-plugin-promise@6.1.1(eslint@7.32.0))(eslint@8.56.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.2.2))(eslint@8.56.0)
       eslint-plugin-n: 16.6.2(eslint@8.56.0)
       eslint-plugin-promise: 6.1.1(eslint@8.56.0)
@@ -20842,7 +20825,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.2.2))(eslint@8.56.0))(eslint-plugin-n@16.6.2(eslint@8.56.0))(eslint-plugin-promise@6.1.1(eslint@7.32.0))(eslint@8.56.0):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.2.2))(eslint@8.56.0))(eslint-plugin-n@16.6.2(eslint@7.32.0))(eslint-plugin-promise@6.1.1(eslint@7.32.0))(eslint@8.56.0):
     dependencies:
       eslint: 8.56.0
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.2.2))(eslint@8.56.0)
@@ -22346,9 +22329,9 @@ snapshots:
 
   human-signals@https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz: {}
 
-  humanize-ms@https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz:
+  humanize-ms@1.2.1:
     dependencies:
-      ms: https://registry.npmjs.org/ms/-/ms-2.1.3.tgz
+      ms: 2.1.3
 
   humanize-string@2.1.0:
     dependencies:
@@ -24057,8 +24040,6 @@ snapshots:
   ms@2.1.3: {}
 
   ms@https://registry.npmjs.org/ms/-/ms-2.1.2.tgz: {}
-
-  ms@https://registry.npmjs.org/ms/-/ms-2.1.3.tgz: {}
 
   multicast-dns@7.2.5:
     dependencies:

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -51,7 +51,7 @@
         "@types/node-fetch": "^2.6.11",
         "@types/proxy": "^1.0.4",
         "@types/string.prototype.matchall": "4.0.1",
-        "agentkeepalive": "4.2.1",
+        "agentkeepalive": "4.6.0",
         "ci-info": "^3.9.0",
         "graceful-fs": "4.2.10",
         "http-proxy-agent": "5.0.0",


### PR DESCRIPTION
This updates `agentkeepalive` to 4.6.0 [to avoid](https://github.com/node-modules/agentkeepalive/pull/114) its [`depd`](https://www.npmjs.com/package/depd) use which augments `Error.prepareStackTrace` and causes an error to be thrown with Node's [`--frozen-intrinsics` flag](https://nodejs.org/api/cli.html#--frozen-intrinsics).