### PR TITLE
fix: use correct GitLab collapsible sections group log format

### DIFF
--- a/log/group/group.spec.ts
+++ b/log/group/group.spec.ts
@@ -42,10 +42,10 @@ test('groups for GitLab', () => {
   const timestamp = Math.floor(DATE_NOW_MOCK / 1000)
   jest.spyOn(Date, 'now').mockImplementation(() => DATE_NOW_MOCK);
   const groupEnd = groupStart('foo')!
-  expect(process.stdout.write).toHaveBeenCalledWith(`section_start:${timestamp}:1\\r\\e[0Kfoo\r\n`);
+  expect(process.stdout.write).toHaveBeenCalledWith(`\x1b[0Ksection_start:${timestamp}:1\r\x1b[0Kfoo\n`);
   expect(process.stdout.write).toHaveBeenCalledTimes(1)
   groupEnd()
-  expect(process.stdout.write).toHaveBeenCalledWith(`section_end:${timestamp}:1\\r\\e[0K`)
+  expect(process.stdout.write).toHaveBeenCalledWith(`\x1b[0Ksection_end:${timestamp}:1\r\x1b[0K\n`)
   expect(process.stdout.write).toHaveBeenCalledTimes(2)
 })
 

--- a/log/group/group.ts
+++ b/log/group/group.ts
@@ -23,8 +23,8 @@ function getLabels (groupName: string) {
   } else if (CI.GITLAB) {
     id++
     return {
-      start: `section_start:${Math.floor(Date.now() / 1000)}:${id}\\r\\e[0K${groupName}\r\n`,
-      end: `section_end:${Math.floor(Date.now() / 1000)}:${id}\\r\\e[0K`,
+      start: `\x1b[0Ksection_start:${Math.floor(Date.now() / 1000)}:${id}\r\x1b[0K${groupName}\n`,
+      end: `\x1b[0Ksection_end:${Math.floor(Date.now() / 1000)}:${id}\r\x1b[0K\n`,
     }
   } else if (CI.TRAVIS) {
     return {


### PR DESCRIPTION
Group logs for GitLab are broken. Node.js doesn't support `\e`. The updated format follows [GitLab's documentation on creating collapsible sections](https://docs.gitlab.com/ci/jobs/job_logs/#create-custom-collapsible-sections).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GitLab CI log grouping display to properly render section markers in logs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/components/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->